### PR TITLE
[JENKINS-48926] - Update Parent POM  and use “Publish Over” plugin with JEP-200 patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-        <version>2.6</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -27,7 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
     <name>Publish Over Dropbox</name>
     <description>Send build artifacts to Dropbox account</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Publish+over+Dropbox+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Publish+over+Dropbox+Plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>
@@ -45,7 +44,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     </developers>
 
     <properties>
-        <jenkins.version>2.6</jenkins.version>
+        <jenkins.version>2.7.3</jenkins.version>
         <java.level>7</java.level>
     </properties>
 
@@ -60,7 +59,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
         <repository>
             <id>uk.maven.org</id>
@@ -78,7 +77,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>publish-over</artifactId>
-            <version>0.18</version>
+            <version>0.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-48926. I confirmed that plugin PCT passes after the dependency update. 

@reviewbybees @jglick @slide 