### PR TITLE
DropboxHostConfiguration: Fix system configuration parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/publishoverdropbox/impl/DropboxHostConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/publishoverdropbox/impl/DropboxHostConfiguration.java
@@ -69,8 +69,8 @@ public class DropboxHostConfiguration extends BPHostConfiguration<DropboxClient,
         return null;
     }
 
-    public DropboxToken getToken() {
-        return token;
+    public String getToken() {
+        return token != null ? token.getId() : null;
     }
 
     public void setToken(final DropboxToken token) {


### PR DESCRIPTION
The getter getToken was giving back an object and not the setter string.

### Testing done

Deploy in company infrastructure and find the culprint of the reason why it was not saved the settings
jenkins page

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
